### PR TITLE
Change /conversation command to /resume command

### DIFF
--- a/crates/paws_main/src/cli.rs
+++ b/crates/paws_main/src/cli.rs
@@ -441,8 +441,9 @@ pub enum ConversationCommand {
 
     /// Resume conversation in interactive mode.
     Resume {
-        /// Conversation ID to resume.
-        id: ConversationId,
+        /// Conversation ID to resume. If not provided, resumes the last
+        /// conversation.
+        id: Option<ConversationId>,
     },
 
     /// Show last assistant message.
@@ -841,7 +842,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conversation_resume() {
+    fn test_conversation_resume_with_id() {
         let fixture = Cli::parse_from([
             "paws",
             "conversation",
@@ -851,14 +852,27 @@ mod tests {
         let id = match fixture.subcommands {
             Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
                 ConversationCommand::Resume { id } => id,
-                _ => ConversationId::default(),
+                _ => None,
             },
-            _ => ConversationId::default(),
+            _ => None,
         };
         assert_eq!(
             id,
-            ConversationId::parse("550e8400-e29b-41d4-a716-446655440005").unwrap()
+            Some(ConversationId::parse("550e8400-e29b-41d4-a716-446655440005").unwrap())
         );
+    }
+
+    #[test]
+    fn test_conversation_resume_without_id() {
+        let fixture = Cli::parse_from(["paws", "conversation", "resume"]);
+        let id = match fixture.subcommands {
+            Some(TopLevelCommand::Conversation(conversation)) => match conversation.command {
+                ConversationCommand::Resume { id } => id,
+                _ => None,
+            },
+            _ => None,
+        };
+        assert_eq!(id, None);
     }
 
     #[test]

--- a/crates/paws_main/src/model.rs
+++ b/crates/paws_main/src/model.rs
@@ -353,6 +353,7 @@ impl PawsCommandManager {
             "/login" => Ok(SlashCommand::Login),
             "/logout" => Ok(SlashCommand::Logout),
             "/retry" => Ok(SlashCommand::Retry),
+            "/resume" => Ok(SlashCommand::Resume),
             "/conversation" | "/conversations" => Ok(SlashCommand::Conversations),
 
             text => {
@@ -485,6 +486,9 @@ pub enum SlashCommand {
     /// Retry without modifying model context
     #[strum(props(usage = "Retry the last command"))]
     Retry,
+    /// Resume the last conversation or a specific conversation
+    #[strum(props(usage = "Resume the last conversation or a specific conversation"))]
+    Resume,
     /// List all conversations for the active workspace
     #[strum(props(usage = "List all conversations for the active workspace"))]
     Conversations,
@@ -528,6 +532,7 @@ impl SlashCommand {
             SlashCommand::Login => "login",
             SlashCommand::Logout => "logout",
             SlashCommand::Retry => "retry",
+            SlashCommand::Resume => "resume",
             SlashCommand::Conversations => "conversation",
             SlashCommand::Delete => "delete",
             SlashCommand::AgentSwitch(agent_id) => agent_id,

--- a/crates/paws_main/src/ui.rs
+++ b/crates/paws_main/src/ui.rs
@@ -697,10 +697,24 @@ impl<A: API + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
                 self.state.conversation_id = original_id;
             }
             ConversationCommand::Resume { id } => {
-                self.validate_conversation_exists(&id).await?;
+                let conversation_id = match id {
+                    Some(id) => {
+                        self.validate_conversation_exists(&id).await?;
+                        id
+                    }
+                    None => {
+                        let last_conversation =
+                            self.api.last_conversation().await?.ok_or_else(|| {
+                                anyhow::anyhow!("No conversation found to resume")
+                            })?;
+                        last_conversation.id
+                    }
+                };
 
-                self.state.conversation_id = Some(id);
-                self.writeln_title(TitleFormat::info(format!("Resumed conversation: {id}")))?;
+                self.state.conversation_id = Some(conversation_id);
+                self.writeln_title(TitleFormat::info(format!(
+                    "Resumed conversation: {conversation_id}"
+                )))?;
                 // Interactive mode will be handled by the main loop
             }
             ConversationCommand::Show { id } => {
@@ -1515,6 +1529,9 @@ impl<A: API + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
             SlashCommand::Conversations => {
                 self.list_conversations().await?;
             }
+            SlashCommand::Resume => {
+                self.handle_resume_conversation().await?;
+            }
             SlashCommand::Compact => {
                 self.spinner.start(Some("Compacting"))?;
                 self.on_compaction().await?;
@@ -1679,6 +1696,21 @@ impl<A: API + 'static, F: Fn() -> A + Send + Sync> UI<A, F> {
     async fn handle_delete_conversation(&mut self) -> anyhow::Result<()> {
         let conversation_id = self.init_conversation().await?;
         self.on_conversation_delete(conversation_id).await?;
+        Ok(())
+    }
+
+    async fn handle_resume_conversation(&mut self) -> anyhow::Result<()> {
+        let last_conversation = self
+            .api
+            .last_conversation()
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("No conversation found to resume"))?;
+
+        self.state.conversation_id = Some(last_conversation.id);
+        self.writeln_title(TitleFormat::info(format!(
+            "Resumed conversation: {}",
+            last_conversation.id
+        )))?;
         Ok(())
     }
 


### PR DESCRIPTION
- Changed Resume command to accept optional conversation ID
- When no ID is provided, resume defaults to last conversation
- Added /resume slash command for interactive mode
- Updated tests to cover both with and without ID cases
- Added handle_resume_conversation() method for slash command handling