### PR TITLE
chore(ci): regenerate workflows from source code

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Cargo Clippy
       run: cargo +nightly clippy --all-features --all-targets --workspace --fix --allow-dirty -- -D warnings
     - name: Autofix
-      uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8
+      uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
 concurrency:
   group: autofix-${{github.ref}}
   cancel-in-progress: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v5
     - name: Setup Protobuf Compiler
       uses: arduino/setup-protoc@v3
       with:


### PR DESCRIPTION
## Problem

Workflow YAML files were manually updated (likely via Dependabot PRs), but the Rust source code that generates them still uses older action versions. This caused a mismatch where:
- `.github/workflows/ci.yml` had `actions/checkout@v6` (manual)
- `.github/workflows/autofix.yml` had `autofix-ci/action@7a166d7...` (manual)
- But the Rust code in `crates/paws_ci/src/` generates with older versions

## Solution

Reverted workflow files to match what the Rust source code generates:
- `actions/checkout@v6` -> `@v5` (matches `Step::checkout()` helper)
- `autofix-ci/action@7a166d7...` -> `@635ffb0...` (matches source)

## Context

Workflows in this project are **auto-generated** from Rust code using the `gh-workflow` crate. The warning at the top of each workflow file states:

> **DO NOT EDIT THIS FILE BY HAND!** Any manual changes will be lost if the file is regenerated.

To update workflows in the future, modify the Rust source in `crates/paws_ci/src/workflows/` and run `cargo test --package paws_ci` to regenerate.

Co-Authored-By: Paws <noreply@pawscode.dev>
